### PR TITLE
Resolves RBQFetchedResultsController issue #3

### DIFF
--- a/Helpers/RLMRealm+Notifications.m
+++ b/Helpers/RLMRealm+Notifications.m
@@ -7,6 +7,7 @@
 //
 
 #import "RLMRealm+Notifications.h"
+#import "RLMObject+Utilities.h"
 #import "RBQRealmNotificationManager.h"
 
 @implementation RLMRealm (Notifications)
@@ -32,7 +33,7 @@
 
 - (void)addOrUpdateObjectWithNotification:(RLMObject *)object
 {
-    if (![self rbq_containsObject:object]) {
+    if (object.realm != self && ![object isContainedInRealm:self]) {
         [[RBQRealmChangeLogger loggerForRealm:self] didAddObject:object];
     }
     else {
@@ -63,28 +64,6 @@
     }
     
     [self deleteObjects:array];
-}
-
-#pragma mark - private helpers
-
-- (BOOL)rbq_containsObject:(RLMObject *)object {
-    if (!object) {
-        return NO;
-    }
-    
-    Class objectClass = [object class];
-    
-    RLMProperty *primaryKeyProperty = object.objectSchema.primaryKeyProperty;
-    
-    if (primaryKeyProperty) {
-        id primaryKeyValue = [object objectForKeyedSubscript:[objectClass primaryKey]];
-        
-        if (!primaryKeyValue) {
-            return NO;
-        }
-        
-        return !![[object class] objectInRealm:self forPrimaryKey:primaryKeyValue];
-    }
 }
 
 @end

--- a/Helpers/RLMRealm+Notifications.m
+++ b/Helpers/RLMRealm+Notifications.m
@@ -32,7 +32,7 @@
 
 - (void)addOrUpdateObjectWithNotification:(RLMObject *)object
 {
-    if (object.realm != self) {
+    if (![self rbq_containsObject:object]) {
         [[RBQRealmChangeLogger loggerForRealm:self] didAddObject:object];
     }
     else {
@@ -63,6 +63,28 @@
     }
     
     [self deleteObjects:array];
+}
+
+#pragma mark - private helpers
+
+- (BOOL)rbq_containsObject:(RLMObject *)object {
+    if (!object) {
+        return NO;
+    }
+    
+    Class objectClass = [object class];
+    
+    RLMProperty *primaryKeyProperty = object.objectSchema.primaryKeyProperty;
+    
+    if (primaryKeyProperty) {
+        id primaryKeyValue = [object objectForKeyedSubscript:[objectClass primaryKey]];
+        
+        if (!primaryKeyValue) {
+            return NO;
+        }
+        
+        return !![[object class] objectInRealm:self forPrimaryKey:primaryKeyValue];
+    }
 }
 
 @end


### PR DESCRIPTION
Fixed an issue where updates were being reported as inserts when the object with primary key already exists.

Had some linking issues when trying adding a new file to the test target but something like this is close to the unit test I was using when I found the issues if you want to add a test for this case (but haven't been able to verify this code or I would add it to the other repo as a PR):

```
- (void)testVerifyUpdateNotification {
    //add object
    TestObject *testObject = [TestObject testObjectWithTitle:@"test"
                                                   sortIndex:1
                                                     inTable:NO];
    testObject.key = @"fish";
    [[RLMRealm defaultRealm] addObject:testObject];

    //set up logger
    RBQRealmChangeLogger *logger = [RBQRealmChangeLogger defaultLogger];

    XCTAssert(logger.entityChanges.allKeys.count == 0);

    //create new object with the same primarykey
    TestObject *testObjectPrime = [TestObject testObjectWithTitle:@"test"
                                                        sortIndex:1
                                                          inTable:NO];
    testObjectPrime.key = testObject.key;
    testObjectPrime.sortIndex = 2;

    //save
    [[RLMRealm defaultRealm] addOrUpdateObject:testObjectPrime];

    //validate results
    NSDictionary *entityChanges = logger.entityChanges;

    RBQEntityChangesObject *entityChangesObject = entityChanges[@"TestObject"];

    XCTAssert([entityChangesObject.className isEqualToString:@"TestObject"]);
    XCTAssert(entityChangesObject.addedSafeObjects.count == 0);
    XCTAssert(entityChangesObject.deletedSafeObjects.count == 0);
    XCTAssert(entityChangesObject.changedSafeObjects.count == 1);
}
```
